### PR TITLE
E-Mail POCs When Contractor with Card is Made Inactive

### DIFF
--- a/Suitability/SendNotification.cs
+++ b/Suitability/SendNotification.cs
@@ -523,6 +523,16 @@ namespace Suitability
         }
 
 
+
+        ///<summary>
+        ///New SendInactiveReminder method developed for GCIMS when contractors are made inactive to remind for PIV card collection
+        ///All the business logic to determin the PIV card eligibility is in DB
+        /// </summary>
+        public void SendInactiveReminder()
+        {
+            HSPD12Email("INAM", string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty);
+        }
+
         /// <summary>
         /// New method that access the DB and gets the email details.
         /// Developed as part of email consolidation.   
@@ -537,7 +547,11 @@ namespace Suitability
             if (emailData.EmailAttachment.IndexOf(";") > 0) {
                 strEmailAttachment = onboardingLocation + emailData.EmailAttachment.Replace(";", string.Concat(";", onboardingLocation));
             }
-            message.Send(emailData.EmailFromAdd, emailData.EmailToAdd, emailData.EmailCCAdd, emailData.EmailBCCAdd, emailData.EmailSubject, emailData.EmailBody, strEmailAttachment, smtpServer, true);
+
+            if (emailData.EmailFromAdd.Contains("@"))
+            {
+                message.Send(emailData.EmailFromAdd, emailData.EmailToAdd, emailData.EmailCCAdd, emailData.EmailBCCAdd, emailData.EmailSubject, emailData.EmailBody, strEmailAttachment, smtpServer, true);
+            }
         }
 
 

--- a/SuitabilityTest/Program.cs
+++ b/SuitabilityTest/Program.cs
@@ -27,7 +27,7 @@ namespace SuitabilityTest
             //persId = 396684;
             //persId = 396686;
             persId = 195705;
-            persId = 143232;
+            //persId = 143232;
             //SendNotification sendNotification = new Suitability.SendNotification(defaultEMail, persId, connectionString, smtpServer, onboarding);
             SendNotification sendNotification = new Suitability.SendNotification(defaultEMail, persId, connectionString, smtpServer, onboarding, ContractId);
             //Calling original Suitability methods

--- a/SuitabilityTest/Program.cs
+++ b/SuitabilityTest/Program.cs
@@ -36,7 +36,7 @@ namespace SuitabilityTest
             sendNotification.SendAdjudicationNotification();
             //sendNotification.SendSponsorshipNotification();
             sendNotification.SendSRSNotification();
-            sendNotification.SendExpiringContractReminder("47PF0018D0039", "Testing from Dev", "2020-06-06", "0", "rajagopalan.ramachandran+CORSSUITDEV@gsa.gov, yun.zheng+CORSSUITDEV@gsa.gov", "david.lenz+zonec@gsa.gov");
+            //sendNotification.SendExpiringContractReminder("47PF0018D0039", "Testing from Dev", "2020-06-06", "0", "rajagopalan.ramachandran+CORSSUITDEV@gsa.gov, yun.zheng+CORSSUITDEV@gsa.gov", "david.lenz+zonec@gsa.gov");
 
         }
     }

--- a/SuitabilityTest/Program.cs
+++ b/SuitabilityTest/Program.cs
@@ -24,8 +24,10 @@ namespace SuitabilityTest
             int ContractId = 34729;
             //persId = 0;
             ContractId = 0;
-            persId = 396684;
+            //persId = 396684;
             //persId = 396686;
+            persId = 195705;
+            persId = 143232;
             //SendNotification sendNotification = new Suitability.SendNotification(defaultEMail, persId, connectionString, smtpServer, onboarding);
             SendNotification sendNotification = new Suitability.SendNotification(defaultEMail, persId, connectionString, smtpServer, onboarding, ContractId);
             //Calling original Suitability methods
@@ -33,10 +35,12 @@ namespace SuitabilityTest
             //sendNotification.SendSponsorshipNotificationV1(); 
 
             // Calling new Suitability methods
-            sendNotification.SendAdjudicationNotification();
+            //sendNotification.SendAdjudicationNotification();
             //sendNotification.SendSponsorshipNotification();
-            sendNotification.SendSRSNotification();
+            //sendNotification.SendSRSNotification();
             //sendNotification.SendExpiringContractReminder("47PF0018D0039", "Testing from Dev", "2020-06-06", "0", "rajagopalan.ramachandran+CORSSUITDEV@gsa.gov, yun.zheng+CORSSUITDEV@gsa.gov", "david.lenz+zonec@gsa.gov");
+            
+            sendNotification.SendInactiveReminder();
 
         }
     }


### PR DESCRIPTION
Implements: https://github.com/GSA/GCIMS/issues/622
When a contractor with an active PIV Card is made inactive in GCIMS by way of the Manual Adjudication, Automated Adjudication, the PMO Update page, or the Employment Update page, an e-mail must be sent to notify that contractor, their GSA POCs, their Vendor POCs, and the relevant HSSO that their card must be returned. This issue is not associated with issue #616.
This issue is due 3/30/2021.